### PR TITLE
Fix nanoid import for CommonJS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ db/
 old/
 __pycache__/
 testing_tools/
+node_modules/
+data/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1085 @@
+{
+  "name": "magic-file-transfer",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "magic-file-transfer",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "express": "^5.1.0",
+        "fs-extra": "^11.3.2",
+        "multer": "^2.0.2",
+        "nanoid": "^5.1.5"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
+      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.0",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.6.3",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.0",
+        "raw-body": "^3.0.0",
+        "type-is": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
+      "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
+      "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.0",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
+      "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "11.3.2",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.2.tgz",
+      "integrity": "sha512-Xr9F6z6up6Ws+NjzMCZc6WXg2YFRlrLP9NQDO3VQrWrfiojdhS56TzueT88ze0uBdCTwEIhQ3ptnmKeWGFAe0A==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-errors/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/multer": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.0.2.tgz",
+      "integrity": "sha512-u7f2xaZ/UG8oLXHvtF/oWTRvT44p9ecwBBqTwgJVq0+4BW1g8OW01TyMEGWBHbyMOYVHXslaut7qEQ1meATXgw==",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.6.0",
+        "concat-stream": "^2.0.0",
+        "mkdirp": "^0.5.6",
+        "object-assign": "^4.1.1",
+        "type-is": "^1.6.18",
+        "xtend": "^4.0.2"
+      },
+      "engines": {
+        "node": ">= 10.16.0"
+      }
+    },
+    "node_modules/multer/node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/multer/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/multer/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/multer/node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.5.tgz",
+      "integrity": "sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.1.tgz",
+      "integrity": "sha512-9G8cA+tuMS75+6G/TzW8OtLzmBDMo8p1JRxN5AZ+LAp8uxGA8V8GZm4GQ4/N5QNQEnLmg6SS7wyuSmbKepiKqA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.7.0",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
+      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
+      "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "mime-types": "^3.0.1",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "magic-file-transfer",
+  "version": "1.0.0",
+  "description": "Node.js rewrite of Magic File Transfer server",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "dev": "node server.js",
+    "test": "echo \"No tests configured\""
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^5.1.0",
+    "fs-extra": "^11.3.2",
+    "multer": "^2.0.2",
+    "nanoid": "^5.1.5"
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,87 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Magic File Transfer</title>
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <main>
+      <section class="card">
+        <h1>Magic File Transfer</h1>
+        <p>
+          Upload large files with resumable, packet-based transfers. Each file is split into indexed packets so that
+          uploads can pause, resume, or recover from interruptions without starting over.
+        </p>
+        <div class="control-row" style="margin-top:1.25rem">
+          <label>
+            <strong>Select files</strong>
+            <input id="fileInput" type="file" multiple />
+          </label>
+          <label>
+            <strong>Chunk size</strong>
+            <select id="chunkSize">
+              <option value="67108864">64 MiB</option>
+              <option value="33554432">32 MiB</option>
+              <option value="16777216">16 MiB</option>
+              <option value="8388608" selected>8 MiB</option>
+              <option value="4194304">4 MiB</option>
+              <option value="2097152">2 MiB</option>
+              <option value="1048576">1 MiB</option>
+              <option value="524288">512 KiB</option>
+              <option value="262144">256 KiB</option>
+            </select>
+          </label>
+          <div>
+            <button id="autoChunk" type="button" class="secondary">Auto optimise</button>
+            <small id="autoChunkHint">Runs a short bandwidth test</small>
+          </div>
+          <label>
+            <input id="persistToggle" type="checkbox" checked />
+            Remember progress if interrupted
+          </label>
+          <button id="startBtn" type="button">Start uploads</button>
+        </div>
+        <div class="control-row" style="margin-top:1rem">
+          <div class="badge">User key: <span id="userKey">--</span></div>
+          <div class="badge">Network packet size: <span id="packetSizeLabel">8 MiB</span></div>
+        </div>
+      </section>
+
+      <section class="card">
+        <div class="section-title">
+          <h2>Active uploads</h2>
+          <small>Each file uploads independently so you can pause or resume individually.</small>
+        </div>
+        <div id="activeUploads" class="upload-list" data-empty-text="No active uploads"></div>
+      </section>
+
+      <section class="card">
+        <div class="section-title">
+          <h2>Paused uploads</h2>
+          <small>Paused transfers stay here until resumed.</small>
+        </div>
+        <div id="pausedUploads" class="upload-list" data-empty-text="No paused uploads"></div>
+      </section>
+
+      <section class="card">
+        <div class="section-title">
+          <h2>Upload history</h2>
+          <button id="clearHistory" type="button" class="secondary">Clear history</button>
+        </div>
+        <div id="history" data-empty-text="No uploads completed yet"></div>
+      </section>
+
+      <section class="card">
+        <div class="section-title">
+          <h2>Transfer log</h2>
+          <button id="clearLog" type="button" class="secondary">Clear log</button>
+        </div>
+        <pre id="log">Ready.</pre>
+      </section>
+    </main>
+
+    <script src="/js/app.js" type="module"></script>
+  </body>
+</html>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1,0 +1,515 @@
+const fileInput = document.getElementById('fileInput');
+const chunkSizeSelect = document.getElementById('chunkSize');
+const startBtn = document.getElementById('startBtn');
+const persistToggle = document.getElementById('persistToggle');
+const packetSizeLabel = document.getElementById('packetSizeLabel');
+const userKeyLabel = document.getElementById('userKey');
+const logView = document.getElementById('log');
+const activeContainer = document.getElementById('activeUploads');
+const pausedContainer = document.getElementById('pausedUploads');
+const historyContainer = document.getElementById('history');
+const clearLogBtn = document.getElementById('clearLog');
+const clearHistoryBtn = document.getElementById('clearHistory');
+const autoChunkBtn = document.getElementById('autoChunk');
+const autoChunkHint = document.getElementById('autoChunkHint');
+
+let userKey = null;
+let uploadsSnapshot = { active: [], paused: [], history: [] };
+const uploadTasks = new Map();
+
+function formatBytes(bytes) {
+  if (!Number.isFinite(bytes)) {
+    return '0 B';
+  }
+  const units = ['B', 'KiB', 'MiB', 'GiB', 'TiB'];
+  let value = bytes;
+  let unitIndex = 0;
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex += 1;
+  }
+  const precision = value >= 10 || unitIndex === 0 ? 0 : 1;
+  return `${value.toFixed(precision)} ${units[unitIndex]}`;
+}
+
+function formatPercent(upload) {
+  if (!upload.totalChunks) return '0%';
+  const percent = (upload.receivedCount / upload.totalChunks) * 100;
+  return `${percent.toFixed(percent === 100 ? 0 : 1)}%`;
+}
+
+function log(message) {
+  const timestamp = new Date().toLocaleTimeString();
+  logView.textContent += `\n[${timestamp}] ${message}`;
+  logView.scrollTop = logView.scrollHeight;
+}
+
+function setSnapshot(snapshot) {
+  uploadsSnapshot = {
+    active: snapshot?.active ?? [],
+    paused: snapshot?.paused ?? [],
+    history: snapshot?.history ?? [],
+  };
+  render();
+}
+
+function updateSnapshotWithUpload(upload) {
+  if (!upload) return;
+  const filtered = (items) => items.filter((item) => item.id !== upload.id);
+  uploadsSnapshot.active = filtered(uploadsSnapshot.active);
+  uploadsSnapshot.paused = filtered(uploadsSnapshot.paused);
+
+  if (upload.status === 'active') {
+    uploadsSnapshot.active.push(upload);
+  } else if (upload.status === 'paused') {
+    uploadsSnapshot.paused.push(upload);
+  }
+  render();
+}
+
+function renderList(container, uploads) {
+  if (!uploads.length) {
+    container.innerHTML = `<small>${container.dataset.emptyText}</small>`;
+    return;
+  }
+
+  container.innerHTML = uploads
+    .map((upload) => {
+      const percent = formatPercent(upload);
+      const missing = upload.missingChunks?.length ?? 0;
+      const chunkCount = `${upload.receivedCount}/${upload.totalChunks} packets`;
+      const actions = [];
+      if (upload.status === 'active') {
+        actions.push(`<button data-upload-action="pause" data-upload-id="${upload.id}" class="secondary">Pause</button>`);
+        actions.push(`<button data-upload-action="cancel" data-upload-id="${upload.id}" class="secondary">Cancel</button>`);
+      } else if (upload.status === 'paused') {
+        actions.push(`<button data-upload-action="resume" data-upload-id="${upload.id}" class="secondary">Resume</button>`);
+        const forgetAction = upload.persist ? 'cancel' : 'forget';
+        const label = upload.persist ? 'Cancel' : 'Forget';
+        actions.push(`<button data-upload-action="${forgetAction}" data-upload-id="${upload.id}" class="secondary">${label}</button>`);
+      }
+
+      return `
+        <div class="upload-item" data-upload-id="${upload.id}">
+          <h3>${upload.fileName}</h3>
+          <div class="upload-meta">
+            <span>${formatBytes(upload.fileSize)}</span>
+            <span>${chunkCount}</span>
+            <span>${missing} packets remaining</span>
+            <span>${upload.persist ? 'Persistent' : 'Ephemeral'}</span>
+          </div>
+          <progress value="${upload.receivedCount}" max="${upload.totalChunks}"></progress>
+          <div class="upload-meta">
+            <span>${percent}</span>
+            <span>Last updated ${new Date(upload.updatedAt).toLocaleTimeString()}</span>
+          </div>
+          <div class="control-row" style="margin-top:0.5rem">${actions.join('')}</div>
+        </div>
+      `;
+    })
+    .join('\n');
+}
+
+function renderHistory(history) {
+  if (!history.length) {
+    historyContainer.innerHTML = `<small>${historyContainer.dataset.emptyText}</small>`;
+    return;
+  }
+
+  historyContainer.innerHTML = history
+    .map((entry) => {
+      const completed = new Date(entry.completedAt);
+      const chunkInfo = `${formatBytes(entry.chunkSize)} packets × ${entry.totalChunks}`;
+      return `
+        <div class="history-item">
+          <div>
+            <strong>${entry.fileName}</strong><br />
+            <small>${formatBytes(entry.fileSize)} • ${chunkInfo} • ${entry.persist ? 'Persistent' : 'Ephemeral'}</small>
+          </div>
+          <div><small>${completed.toLocaleString()}</small></div>
+        </div>
+      `;
+    })
+    .join('\n');
+}
+
+function render() {
+  renderList(activeContainer, uploadsSnapshot.active);
+  renderList(pausedContainer, uploadsSnapshot.paused);
+  renderHistory(uploadsSnapshot.history);
+}
+
+async function identifyUser() {
+  const storedKey = localStorage.getItem('mft.userKey');
+  const response = await fetch('/api/users/identify', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ userKey: storedKey }),
+  });
+  if (!response.ok) {
+    throw new Error('Unable to reach server');
+  }
+  const data = await response.json();
+  userKey = data.userKey;
+  localStorage.setItem('mft.userKey', userKey);
+  userKeyLabel.textContent = userKey;
+  setSnapshot(data.uploads);
+  log(`Signed in with user key ${userKey}.`);
+}
+
+function updatePacketLabel() {
+  const size = Number(chunkSizeSelect.value);
+  packetSizeLabel.textContent = formatBytes(size);
+}
+
+class UploadTask {
+  constructor(file, uploadMeta, options) {
+    this.file = file;
+    this.meta = uploadMeta;
+    this.userKey = options.userKey;
+    this.chunkSize = options.chunkSize;
+    this.persist = options.persist;
+    this.queue = uploadMeta.missingChunks ? uploadMeta.missingChunks.slice() : [];
+    this.queue.sort((a, b) => a - b);
+    this.paused = false;
+    this.cancelled = false;
+    this.currentController = null;
+    this.resumeResolver = null;
+    this.loopPromise = null;
+  }
+
+  start() {
+    if (this.loopPromise) return this.loopPromise;
+    this.loopPromise = this.processQueue();
+    return this.loopPromise;
+  }
+
+  pause() {
+    this.paused = true;
+    if (this.currentController) {
+      this.currentController.abort();
+    }
+  }
+
+  cancel() {
+    this.cancelled = true;
+    this.pause();
+    if (this.resumeResolver) {
+      this.resumeResolver();
+      this.resumeResolver = null;
+    }
+  }
+
+  resume(upload) {
+    if (upload) {
+      this.meta = upload;
+      this.queue = upload.missingChunks ? upload.missingChunks.slice().sort((a, b) => a - b) : [];
+    }
+    this.paused = false;
+    if (this.resumeResolver) {
+      this.resumeResolver();
+      this.resumeResolver = null;
+    }
+    if (!this.loopPromise) {
+      this.start();
+    }
+  }
+
+  async processQueue() {
+    while (!this.cancelled) {
+      if (this.paused) {
+        await new Promise((resolve) => {
+          this.resumeResolver = resolve;
+        });
+        this.resumeResolver = null;
+        if (this.cancelled) break;
+        if (this.paused) continue;
+      }
+
+      const nextIndex = this.queue.shift();
+      if (nextIndex === undefined) {
+        break;
+      }
+
+      try {
+        const status = await this.uploadChunk(nextIndex);
+        if (status === 'completed') {
+          this.cancelled = true;
+          uploadTasks.delete(this.meta.id);
+          break;
+        }
+      } catch (error) {
+        if (error.name === 'AbortError') {
+          this.queue.unshift(nextIndex);
+          continue;
+        }
+        log(`[${this.file.name}] chunk ${nextIndex} failed: ${error.message}`);
+        this.queue.unshift(nextIndex);
+        this.pause();
+        if (this.persist) {
+          try {
+            await postUploadAction(this.meta.id, 'pause');
+          } catch (actionError) {
+            log(`Failed to notify pause: ${actionError.message}`);
+          }
+          log(`[${this.file.name}] paused due to network error.`);
+        } else {
+          try {
+            await postUploadAction(this.meta.id, 'forget');
+          } catch (actionError) {
+            log(`Failed to discard upload: ${actionError.message}`);
+          }
+          uploadTasks.delete(this.meta.id);
+          log(`[${this.file.name}] upload cancelled (non-persistent).`);
+          this.cancelled = true;
+        }
+      }
+    }
+  }
+
+  async uploadChunk(index) {
+    const start = index * this.chunkSize;
+    const end = Math.min(start + this.chunkSize, this.file.size);
+    const blob = this.file.slice(start, end);
+
+    const form = new FormData();
+    form.append('userKey', this.userKey);
+    form.append('chunkIndex', String(index));
+    form.append('chunk', blob, `${this.file.name}.part`);
+
+    this.currentController = new AbortController();
+    const response = await fetch(`/api/uploads/${this.meta.id}/chunk`, {
+      method: 'POST',
+      body: form,
+      signal: this.currentController.signal,
+    });
+
+    if (!response.ok) {
+      throw new Error(`Server responded ${response.status}`);
+    }
+
+    const data = await response.json();
+    if (data.status === 'completed') {
+      if (data.uploads) {
+        setSnapshot(data.uploads);
+      }
+      log(`[${this.file.name}] upload complete.`);
+      return 'completed';
+    }
+
+    if (data.upload) {
+      this.meta = data.upload;
+      this.queue = data.upload.missingChunks.slice().sort((a, b) => a - b);
+      updateSnapshotWithUpload(data.upload);
+      log(`[${this.file.name}] ${formatPercent(data.upload)} complete.`);
+    }
+
+    return 'ok';
+  }
+}
+
+async function postUploadAction(uploadId, action) {
+  const response = await fetch(`/api/uploads/${uploadId}/state`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ userKey, action }),
+  });
+  if (!response.ok) {
+    throw new Error(`Action ${action} failed`);
+  }
+  const data = await response.json();
+  if (data.uploads) {
+    setSnapshot(data.uploads);
+  }
+  return data;
+}
+
+async function startUploads() {
+  if (!userKey) {
+    log('Waiting for server connection. Please try again in a moment.');
+    return;
+  }
+
+  const files = Array.from(fileInput.files || []);
+  if (!files.length) {
+    log('Select files to upload first.');
+    return;
+  }
+
+  const chunkSize = Number(chunkSizeSelect.value);
+  const persist = persistToggle.checked;
+
+  for (const file of files) {
+    const pausedMatch = uploadsSnapshot.paused.find((upload) => upload.fileName === file.name && upload.fileSize === file.size);
+    if (pausedMatch) {
+      try {
+        const metaResponse = await fetch(`/api/uploads/${pausedMatch.id}?userKey=${encodeURIComponent(userKey)}`);
+        if (!metaResponse.ok) {
+          throw new Error('Failed to load paused upload metadata');
+        }
+        const metaData = await metaResponse.json();
+        const uploadMeta = metaData.upload;
+        if (!uploadMeta) {
+          throw new Error('Upload metadata unavailable');
+        }
+        const task = new UploadTask(file, uploadMeta, {
+          userKey,
+          chunkSize: uploadMeta.chunkSize,
+          persist: pausedMatch.persist,
+        });
+        uploadTasks.set(pausedMatch.id, task);
+        const resumeData = await postUploadAction(pausedMatch.id, 'resume');
+        if (resumeData.upload) {
+          task.resume(resumeData.upload);
+        }
+        log(`Resuming ${file.name} (${formatBytes(file.size)}).`);
+      } catch (error) {
+        log(`Failed to resume ${file.name}: ${error.message}`);
+      }
+      continue;
+    }
+
+    try {
+      const response = await fetch('/api/uploads', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          userKey,
+          fileName: file.name,
+          fileSize: file.size,
+          chunkSize,
+          persist,
+        }),
+      });
+      if (!response.ok) {
+        throw new Error(`Failed to create upload (${response.status})`);
+      }
+      const data = await response.json();
+      const upload = data.upload;
+      updateSnapshotWithUpload(upload);
+      const task = new UploadTask(file, upload, { userKey, chunkSize, persist });
+      uploadTasks.set(upload.id, task);
+      task.start();
+      log(`Uploading ${file.name} (${formatBytes(file.size)}) with ${formatBytes(chunkSize)} packets.`);
+    } catch (error) {
+      log(`Failed to start upload for ${file.name}: ${error.message}`);
+    }
+  }
+
+  fileInput.value = '';
+}
+
+
+async function clearHistory() {
+  if (!userKey) return;
+  const response = await fetch('/api/uploads/history', {
+    method: 'DELETE',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ userKey }),
+  });
+  if (!response.ok) {
+    log('Failed to clear history.');
+    return;
+  }
+  const data = await response.json();
+  setSnapshot(data);
+  log('Upload history cleared.');
+}
+
+function handleUploadButtonClick(event) {
+  const action = event.target?.dataset?.uploadAction;
+  const uploadId = event.target?.dataset?.uploadId;
+  if (!action || !uploadId) return;
+  event.preventDefault();
+
+  const task = uploadTasks.get(uploadId);
+  if (action === 'pause' && task) {
+    task.pause();
+  }
+  if ((action === 'cancel' || action === 'forget') && task) {
+    task.cancel();
+    uploadTasks.delete(uploadId);
+  }
+
+  postUploadAction(uploadId, action)
+    .then((data) => {
+      const labelMap = {
+        pause: 'Paused',
+        resume: 'Resumed',
+        cancel: 'Cancelled',
+        forget: 'Forgot',
+      };
+      const targetName = data.upload?.fileName || uploadId;
+      if (labelMap[action]) {
+        log(`${labelMap[action]} ${targetName}.`);
+      }
+      if (action === 'resume') {
+        const updated = data.upload;
+        const resumeTask = uploadTasks.get(uploadId);
+        if (resumeTask) {
+          resumeTask.resume(updated);
+        } else if (updated) {
+          log(`Select the original file to resume upload ${updated.fileName}.`);
+        }
+      }
+    })
+    .catch((error) => {
+      log(`Action ${action} failed: ${error.message}`);
+    });
+}
+
+async function runAutoChunkSizing() {
+  autoChunkBtn.disabled = true;
+  autoChunkHint.textContent = 'Testing bandwidth…';
+  try {
+    const sampleSize = 512 * 1024;
+    const buffer = new Uint8Array(sampleSize);
+    const form = new FormData();
+    form.append('sample', new Blob([buffer]), 'probe.bin');
+    const response = await fetch('/api/network/probe', {
+      method: 'POST',
+      body: form,
+    });
+    if (!response.ok) {
+      throw new Error(`Probe failed (${response.status})`);
+    }
+    const data = await response.json();
+    const elapsed = data.elapsedMs ?? 0;
+    const throughput = data.bytes && elapsed ? data.bytes / (elapsed / 1000) : 0;
+    const targetSeconds = 4;
+    const desiredSize = throughput * targetSeconds;
+    const options = Array.from(chunkSizeSelect.options).map((opt) => Number(opt.value));
+    const best = options.reduce((closest, size) => {
+      if (!closest) return size;
+      const diff = Math.abs(size - desiredSize);
+      const closestDiff = Math.abs(closest - desiredSize);
+      if (diff < closestDiff) return size;
+      if (diff === closestDiff && size > closest) return size;
+      return closest;
+    }, options[0]);
+    chunkSizeSelect.value = String(best);
+    updatePacketLabel();
+    log(`Auto selected ${formatBytes(best)} packets (~${formatBytes(throughput)}/s).`);
+    autoChunkHint.textContent = `Recommended: ${formatBytes(best)}`;
+  } catch (error) {
+    autoChunkHint.textContent = 'Auto sizing unavailable';
+    log(`Auto chunk sizing failed: ${error.message}`);
+  } finally {
+    autoChunkBtn.disabled = false;
+  }
+}
+
+clearLogBtn.addEventListener('click', () => {
+  logView.textContent = 'Ready.';
+});
+
+clearHistoryBtn.addEventListener('click', clearHistory);
+startBtn.addEventListener('click', startUploads);
+chunkSizeSelect.addEventListener('change', updatePacketLabel);
+autoChunkBtn.addEventListener('click', runAutoChunkSizing);
+document.addEventListener('click', handleUploadButtonClick);
+
+identifyUser().catch((error) => {
+  log(`Failed to initialise: ${error.message}`);
+});
+updatePacketLabel();

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,169 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+body {
+  margin: 0;
+  background: #f5f7fb;
+  color: #1f2430;
+}
+
+main {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 3rem 1.5rem 4rem;
+}
+
+h1 {
+  font-size: clamp(2rem, 3vw, 2.75rem);
+  margin-bottom: 1rem;
+}
+
+.card {
+  background: #fff;
+  border-radius: 16px;
+  box-shadow: 0 12px 35px rgba(15, 23, 42, 0.08);
+  padding: 1.75rem;
+  margin-bottom: 1.5rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.control-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+}
+
+input[type='file'] {
+  display: block;
+}
+
+select,
+button,
+input[type='checkbox'] {
+  font-size: 0.95rem;
+  padding: 0.55rem 0.85rem;
+  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: #f8f9ff;
+  color: inherit;
+}
+
+button {
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  background: linear-gradient(135deg, #5469d4, #7886ff);
+  border: none;
+  color: #fff;
+  box-shadow: 0 10px 25px rgba(84, 105, 212, 0.24);
+}
+
+button.secondary {
+  background: #fff;
+  color: #1f2430;
+  box-shadow: none;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+button:not(:disabled):hover {
+  transform: translateY(-1px);
+}
+
+progress {
+  width: 100%;
+  height: 14px;
+}
+
+.upload-list {
+  display: grid;
+  gap: 1rem;
+}
+
+.upload-item {
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 12px;
+  padding: 1rem 1.2rem;
+  background: #fdfdff;
+}
+
+.upload-item h3 {
+  margin-top: 0;
+  margin-bottom: 0.35rem;
+}
+
+.upload-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  font-size: 0.9rem;
+  color: #475569;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.8rem;
+  background: rgba(84, 105, 212, 0.12);
+  color: #3949ab;
+  border-radius: 999px;
+  padding: 0.2rem 0.65rem;
+}
+
+.section-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.75rem;
+}
+
+.history-item {
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+  padding: 0.65rem 0;
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  font-size: 0.9rem;
+}
+
+.history-item:last-child {
+  border-bottom: none;
+}
+
+small {
+  color: #64748b;
+}
+
+#log {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  background: #0f172a;
+  color: #e2e8f0;
+  border-radius: 12px;
+  padding: 1rem;
+  min-height: 120px;
+  max-height: 300px;
+  overflow-y: auto;
+  white-space: pre-wrap;
+}
+
+@media (max-width: 720px) {
+  .control-row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  button,
+  select {
+    width: 100%;
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,261 @@
+const path = require('path');
+const express = require('express');
+const multer = require('multer');
+const fs = require('fs-extra');
+const UploadManager = require('./src/uploadManager');
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+const ROOT = __dirname;
+const DATA_DIR = path.join(ROOT, 'data');
+const UPLOAD_DIR = path.join(DATA_DIR, 'uploads');
+const FINAL_DIR = path.join(DATA_DIR, 'files');
+const STATE_PATH = path.join(DATA_DIR, 'state.json');
+
+const manager = new UploadManager({
+  rootDir: ROOT,
+  uploadDir: UPLOAD_DIR,
+  finalDir: FINAL_DIR,
+  statePath: STATE_PATH,
+});
+
+fs.ensureDirSync(UPLOAD_DIR);
+fs.ensureDirSync(FINAL_DIR);
+
+const chunkUpload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 80 * 1024 * 1024 },
+});
+
+const probeUpload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 5 * 1024 * 1024 },
+});
+
+app.use(express.json({ limit: '1mb' }));
+app.use(express.urlencoded({ extended: true }));
+app.use((req, res, next) => {
+  req.startTime = Date.now();
+  next();
+});
+
+app.use(express.static(path.join(ROOT, 'public')));
+
+function parseInteger(value, fieldName) {
+  const result = Number.parseInt(value, 10);
+  if (Number.isNaN(result)) {
+    const err = new Error(`invalid_${fieldName}`);
+    err.statusCode = 400;
+    throw err;
+  }
+  return result;
+}
+
+async function ensureChunkDirectory(uploadId) {
+  const dir = path.join(UPLOAD_DIR, uploadId);
+  await fs.ensureDir(dir);
+  return dir;
+}
+
+function sanitizeError(err) {
+  if (err instanceof Error && err.statusCode) {
+    return err;
+  }
+  const error = new Error('internal_error');
+  error.statusCode = 500;
+  if (process.env.NODE_ENV !== 'production') {
+    error.details = err.message;
+  }
+  return error;
+}
+
+app.post('/api/users/identify', async (req, res, next) => {
+  try {
+    const requestedKey = req.body?.userKey || req.query?.userKey;
+    const result = await manager.identifyUser(requestedKey);
+    const snapshot = (await manager.getUserSnapshot(result.userKey)) || { active: [], paused: [], history: [] };
+    res.json({ userKey: result.userKey, created: result.created, uploads: snapshot });
+  } catch (err) {
+    next(err);
+  }
+});
+
+app.get('/api/uploads', async (req, res, next) => {
+  try {
+    const userKey = req.query.userKey;
+    if (!userKey) {
+      const error = new Error('missing_user_key');
+      error.statusCode = 400;
+      throw error;
+    }
+    const snapshot = await manager.getUserSnapshot(userKey);
+    if (!snapshot) {
+      const error = new Error('user_not_found');
+      error.statusCode = 404;
+      throw error;
+    }
+    res.json(snapshot);
+  } catch (err) {
+    next(err);
+  }
+});
+
+app.get('/api/uploads/:uploadId', async (req, res, next) => {
+  try {
+    const userKey = req.query.userKey;
+    if (!userKey) {
+      const error = new Error('missing_user_key');
+      error.statusCode = 400;
+      throw error;
+    }
+    const uploadResult = await manager.getUpload(userKey, req.params.uploadId);
+    if (!uploadResult) {
+      const error = new Error('upload_not_found');
+      error.statusCode = 404;
+      throw error;
+    }
+    res.json({ upload: uploadResult.upload, location: uploadResult.location });
+  } catch (err) {
+    next(err);
+  }
+});
+
+app.post('/api/uploads', async (req, res, next) => {
+  try {
+    const { userKey, fileName, fileSize, chunkSize, persist = true } = req.body || {};
+    if (!userKey || !fileName) {
+      const error = new Error('missing_fields');
+      error.statusCode = 400;
+      throw error;
+    }
+    const size = Number(fileSize);
+    const chunk = Number(chunkSize);
+    if (!Number.isFinite(size) || !Number.isFinite(chunk) || size <= 0 || chunk <= 0) {
+      const error = new Error('invalid_sizes');
+      error.statusCode = 400;
+      throw error;
+    }
+    const upload = await manager.createUpload(userKey, {
+      fileName,
+      fileSize: size,
+      chunkSize: chunk,
+      persist: persist !== false && persist !== 'false',
+    });
+    res.json({ upload });
+  } catch (err) {
+    next(err);
+  }
+});
+
+app.post('/api/uploads/:uploadId/chunk', chunkUpload.single('chunk'), async (req, res, next) => {
+  try {
+    const uploadId = req.params.uploadId;
+    const { userKey, chunkIndex } = req.body || {};
+    if (!userKey) {
+      const error = new Error('missing_user_key');
+      error.statusCode = 400;
+      throw error;
+    }
+    if (!req.file) {
+      const error = new Error('missing_chunk');
+      error.statusCode = 400;
+      throw error;
+    }
+    const index = parseInteger(chunkIndex, 'chunk_index');
+    const chunkDir = await ensureChunkDirectory(uploadId);
+    const chunkPath = path.join(chunkDir, `${index}.part`);
+
+    const exists = await fs.pathExists(chunkPath);
+    if (!exists) {
+      await fs.writeFile(chunkPath, req.file.buffer);
+    }
+
+    const record = await manager.recordChunk(userKey, uploadId, index);
+
+    if (record.completed) {
+      const finalizedUpload = record.upload;
+      await manager.assembleFile(finalizedUpload);
+      await manager.finalizeUpload(userKey, uploadId);
+      const snapshot = await manager.getUserSnapshot(userKey);
+      res.json({ status: 'completed', upload: finalizedUpload, uploads: snapshot });
+      return;
+    }
+
+    res.json({ status: 'ok', upload: record.upload });
+  } catch (err) {
+    next(err);
+  }
+});
+
+app.post('/api/uploads/:uploadId/state', async (req, res, next) => {
+  try {
+    const { action, userKey } = req.body || {};
+    if (!userKey || !action) {
+      const error = new Error('missing_fields');
+      error.statusCode = 400;
+      throw error;
+    }
+    let response;
+    if (action === 'pause') {
+      response = await manager.updateStatus(userKey, req.params.uploadId, 'paused');
+    } else if (action === 'resume') {
+      response = await manager.updateStatus(userKey, req.params.uploadId, 'active');
+    } else if (action === 'cancel') {
+      response = await manager.removeUpload(userKey, req.params.uploadId, { forget: false });
+      await fs.remove(path.join(UPLOAD_DIR, req.params.uploadId));
+    } else if (action === 'forget') {
+      response = await manager.removeUpload(userKey, req.params.uploadId, { forget: true });
+      await fs.remove(path.join(UPLOAD_DIR, req.params.uploadId));
+    } else {
+      const error = new Error('invalid_action');
+      error.statusCode = 400;
+      throw error;
+    }
+    const snapshot = await manager.getUserSnapshot(userKey);
+    res.json({ upload: response, uploads: snapshot });
+  } catch (err) {
+    next(err);
+  }
+});
+
+app.delete('/api/uploads/history', async (req, res, next) => {
+  try {
+    const userKey = req.body?.userKey || req.query?.userKey;
+    if (!userKey) {
+      const error = new Error('missing_user_key');
+      error.statusCode = 400;
+      throw error;
+    }
+    await manager.clearHistory(userKey);
+    const snapshot = await manager.getUserSnapshot(userKey);
+    res.json(snapshot);
+  } catch (err) {
+    next(err);
+  }
+});
+
+app.post('/api/network/probe', probeUpload.single('sample'), async (req, res, next) => {
+  try {
+    if (!req.file) {
+      const error = new Error('missing_sample');
+      error.statusCode = 400;
+      throw error;
+    }
+    const elapsedMs = Date.now() - req.startTime;
+    res.json({ bytes: req.file.buffer.length, elapsedMs });
+  } catch (err) {
+    next(err);
+  }
+});
+
+app.use((err, req, res, next) => {
+  const error = sanitizeError(err);
+  if (process.env.NODE_ENV !== 'production') {
+    console.error(err);
+  }
+  res.status(error.statusCode || 500).json({ error: error.message, details: error.details });
+});
+
+app.listen(PORT, () => {
+  console.log(`Magic File Transfer Node server listening on http://localhost:${PORT}`);
+});

--- a/src/datastore.js
+++ b/src/datastore.js
@@ -1,0 +1,46 @@
+const fs = require('fs-extra');
+
+class DataStore {
+  constructor(filePath) {
+    this.filePath = filePath;
+    this._lock = Promise.resolve();
+  }
+
+  async _read() {
+    try {
+      return await fs.readJson(this.filePath);
+    } catch (err) {
+      if (err.code === 'ENOENT') {
+        return { users: {} };
+      }
+      throw err;
+    }
+  }
+
+  async _write(state) {
+    await fs.outputJson(this.filePath, state, { spaces: 2 });
+  }
+
+  async withState(mutator) {
+    this._lock = this._lock.then(async () => {
+      const state = await this._read();
+      const result = await mutator(state);
+      await this._write(state);
+      return result;
+    });
+    return this._lock;
+  }
+
+  async readState(selector) {
+    let finalResult;
+    this._lock = this._lock.then(async () => {
+      const state = await this._read();
+      finalResult = selector ? await selector(state) : state;
+      return finalResult;
+    });
+    await this._lock;
+    return finalResult;
+  }
+}
+
+module.exports = DataStore;

--- a/src/uploadManager.js
+++ b/src/uploadManager.js
@@ -1,0 +1,401 @@
+const path = require('path');
+const fs = require('fs-extra');
+const DataStore = require('./datastore');
+
+const userIdAlphabet = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+const fileIdAlphabet = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
+
+let customAlphabetPromise = null;
+async function loadCustomAlphabet() {
+  if (!customAlphabetPromise) {
+    customAlphabetPromise = import('nanoid').then((mod) => mod.customAlphabet);
+  }
+  return customAlphabetPromise;
+}
+
+class UploadManager {
+  constructor({ rootDir, uploadDir, finalDir, statePath }) {
+    this.rootDir = rootDir;
+    this.uploadDir = uploadDir;
+    this.finalDir = finalDir;
+    this.store = new DataStore(statePath);
+    this.ephemeral = new Map();
+    this._createUserId = null;
+    this._createFileId = null;
+  }
+
+  _now() {
+    return new Date().toISOString();
+  }
+
+  _deepClone(value) {
+    return JSON.parse(JSON.stringify(value));
+  }
+
+  _ensureUserRecord(state, userKey) {
+    if (!state.users[userKey]) {
+      state.users[userKey] = {
+        key: userKey,
+        createdAt: this._now(),
+        uploads: {},
+        history: [],
+      };
+    }
+    const user = state.users[userKey];
+    user.uploads = user.uploads || {};
+    user.history = user.history || [];
+    return user;
+  }
+
+  _ensureEphemeralUser(userKey) {
+    if (!this.ephemeral.has(userKey)) {
+      this.ephemeral.set(userKey, { uploads: new Map() });
+    }
+    return this.ephemeral.get(userKey);
+  }
+
+  async _ensureIdFactories() {
+    if (!this._createUserId || !this._createFileId) {
+      const customAlphabet = await loadCustomAlphabet();
+      this._createUserId = customAlphabet(userIdAlphabet, 16);
+      this._createFileId = customAlphabet(fileIdAlphabet, 20);
+    }
+  }
+
+  async identifyUser(requestedKey) {
+    await this._ensureIdFactories();
+    if (requestedKey) {
+      const exists = await this.store.readState((state) => state.users[requestedKey] ? true : false);
+      if (exists) {
+        this._ensureEphemeralUser(requestedKey);
+        return { userKey: requestedKey, created: false };
+      }
+    }
+
+    const result = await this.store.withState((state) => {
+      let candidate = requestedKey;
+      if (!candidate || state.users[candidate]) {
+        do {
+          candidate = this._createUserId();
+        } while (state.users[candidate]);
+      }
+      if (!state.users[candidate]) {
+        state.users[candidate] = {
+          key: candidate,
+          createdAt: this._now(),
+          uploads: {},
+          history: [],
+        };
+      }
+      return { userKey: candidate, created: true };
+    });
+
+    this._ensureEphemeralUser(result.userKey);
+    return result;
+  }
+
+  _decorateUpload(upload) {
+    const clone = this._deepClone(upload);
+    const missing = this._missingChunks(clone);
+    clone.missingChunks = missing;
+    clone.receivedCount = clone.totalChunks - missing.length;
+    return clone;
+  }
+
+  _missingChunks(upload) {
+    const missing = [];
+    const received = upload.receivedChunks || {};
+    for (let i = 0; i < upload.totalChunks; i += 1) {
+      if (!received[i]) {
+        missing.push(i);
+      }
+    }
+    return missing;
+  }
+
+  async getUserSnapshot(userKey) {
+    const persistentUser = await this.store.readState((state) => {
+      const user = state.users[userKey];
+      return user ? this._deepClone(user) : null;
+    });
+
+    if (!persistentUser && !this.ephemeral.has(userKey)) {
+      return null;
+    }
+
+    const active = [];
+    const paused = [];
+    const history = persistentUser ? (persistentUser.history || []) : [];
+
+    if (persistentUser) {
+      const uploads = persistentUser.uploads || {};
+      Object.values(uploads).forEach((upload) => {
+        const decorated = this._decorateUpload(upload);
+        if (decorated.status === 'paused') {
+          paused.push(decorated);
+        } else {
+          active.push(decorated);
+        }
+      });
+    }
+
+    const ephemeralUser = this.ephemeral.get(userKey);
+    if (ephemeralUser) {
+      for (const upload of ephemeralUser.uploads.values()) {
+        const decorated = this._decorateUpload(upload);
+        if (decorated.status === 'paused') {
+          paused.push(decorated);
+        } else {
+          active.push(decorated);
+        }
+      }
+    }
+
+    return { active, paused, history };
+  }
+
+  async createUpload(userKey, { fileName, fileSize, chunkSize, persist }) {
+    await this._ensureIdFactories();
+    const totalChunks = Math.ceil(fileSize / chunkSize);
+    const uploadId = this._createFileId();
+    const now = this._now();
+    const baseMetadata = {
+      id: uploadId,
+      userKey,
+      fileName,
+      fileSize,
+      chunkSize,
+      totalChunks,
+      persist: persist !== false,
+      status: 'active',
+      receivedChunks: {},
+      receivedCount: 0,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    if (baseMetadata.persist) {
+      await this.store.withState((state) => {
+        const user = this._ensureUserRecord(state, userKey);
+        user.uploads[uploadId] = baseMetadata;
+        return null;
+      });
+    } else {
+      const user = this._ensureEphemeralUser(userKey);
+      user.uploads.set(uploadId, baseMetadata);
+    }
+
+    await fs.ensureDir(path.join(this.uploadDir, uploadId));
+    return this._decorateUpload(baseMetadata);
+  }
+
+  async getUpload(userKey, uploadId) {
+    const ephemeralUser = this.ephemeral.get(userKey);
+    if (ephemeralUser && ephemeralUser.uploads.has(uploadId)) {
+      const upload = ephemeralUser.uploads.get(uploadId);
+      return { location: 'memory', upload: this._decorateUpload(upload) };
+    }
+
+    const exists = await this.store.readState((state) => {
+      const user = state.users[userKey];
+      if (!user) return null;
+      const upload = user.uploads ? user.uploads[uploadId] : null;
+      return upload ? this._decorateUpload(upload) : null;
+    });
+
+    if (!exists) {
+      return null;
+    }
+
+    return { location: 'persistent', upload: exists };
+  }
+
+  async recordChunk(userKey, uploadId, chunkIndex) {
+    const memoryUser = this.ephemeral.get(userKey);
+    if (memoryUser && memoryUser.uploads.has(uploadId)) {
+      const upload = memoryUser.uploads.get(uploadId);
+      this._markChunk(upload, chunkIndex);
+      const decorated = this._decorateUpload(upload);
+      return { upload: decorated, completed: decorated.missingChunks.length === 0 };
+    }
+
+    return this.store.withState((state) => {
+      const user = state.users[userKey];
+      if (!user || !user.uploads || !user.uploads[uploadId]) {
+        throw new Error('upload_not_found');
+      }
+      const upload = user.uploads[uploadId];
+      this._markChunk(upload, chunkIndex);
+      const decorated = this._decorateUpload(upload);
+      return { upload: decorated, completed: decorated.missingChunks.length === 0 };
+    });
+  }
+
+  _markChunk(upload, chunkIndex) {
+    if (chunkIndex < 0 || chunkIndex >= upload.totalChunks) {
+      throw new Error('chunk_out_of_range');
+    }
+    if (!upload.receivedChunks) {
+      upload.receivedChunks = {};
+    }
+    if (!upload.receivedChunks[chunkIndex]) {
+      upload.receivedChunks[chunkIndex] = true;
+    }
+    upload.receivedCount = Object.keys(upload.receivedChunks).length;
+    upload.status = 'active';
+    upload.updatedAt = this._now();
+  }
+
+  async updateStatus(userKey, uploadId, status) {
+    const memoryUser = this.ephemeral.get(userKey);
+    if (memoryUser && memoryUser.uploads.has(uploadId)) {
+      const upload = memoryUser.uploads.get(uploadId);
+      upload.status = status;
+      upload.updatedAt = this._now();
+      return this._decorateUpload(upload);
+    }
+
+    return this.store.withState((state) => {
+      const user = state.users[userKey];
+      if (!user || !user.uploads || !user.uploads[uploadId]) {
+        throw new Error('upload_not_found');
+      }
+      const upload = user.uploads[uploadId];
+      upload.status = status;
+      upload.updatedAt = this._now();
+      return this._decorateUpload(upload);
+    });
+  }
+
+  async finalizeUpload(userKey, uploadId) {
+    const memoryUser = this.ephemeral.get(userKey);
+    if (memoryUser && memoryUser.uploads.has(uploadId)) {
+      const upload = memoryUser.uploads.get(uploadId);
+      upload.status = 'completed';
+      upload.completedAt = this._now();
+      memoryUser.uploads.delete(uploadId);
+      await this.store.withState((state) => {
+        const user = this._ensureUserRecord(state, userKey);
+        user.history.unshift(this._toHistoryEntry(upload));
+        if (user.history.length > 200) {
+          user.history = user.history.slice(0, 200);
+        }
+        return null;
+      });
+      return this._decorateUpload(upload);
+    }
+
+    return this.store.withState((state) => {
+      const user = state.users[userKey];
+      if (!user || !user.uploads || !user.uploads[uploadId]) {
+        throw new Error('upload_not_found');
+      }
+      const upload = user.uploads[uploadId];
+      upload.status = 'completed';
+      upload.completedAt = this._now();
+      const decorated = this._decorateUpload(upload);
+      user.history.unshift(this._toHistoryEntry(upload));
+      if (user.history.length > 200) {
+        user.history = user.history.slice(0, 200);
+      }
+      delete user.uploads[uploadId];
+      return decorated;
+    });
+  }
+
+  _toHistoryEntry(upload) {
+    return {
+      id: upload.id,
+      fileName: upload.fileName,
+      fileSize: upload.fileSize,
+      completedAt: upload.completedAt || this._now(),
+      chunkSize: upload.chunkSize,
+      totalChunks: upload.totalChunks,
+      persist: upload.persist !== false,
+    };
+  }
+
+  async clearHistory(userKey) {
+    return this.store.withState((state) => {
+      const user = state.users[userKey];
+      if (!user) {
+        throw new Error('user_not_found');
+      }
+      user.history = [];
+      return [];
+    });
+  }
+
+  async removeUpload(userKey, uploadId, { forget = false } = {}) {
+    const memoryUser = this.ephemeral.get(userKey);
+    if (memoryUser && memoryUser.uploads.has(uploadId)) {
+      const upload = memoryUser.uploads.get(uploadId);
+      memoryUser.uploads.delete(uploadId);
+      if (!forget) {
+        await this.store.withState((state) => {
+          const user = this._ensureUserRecord(state, userKey);
+          user.history.unshift(this._toHistoryEntry(upload));
+          if (user.history.length > 200) {
+            user.history = user.history.slice(0, 200);
+          }
+          return null;
+        });
+      }
+      return this._decorateUpload(upload);
+    }
+
+    return this.store.withState((state) => {
+      const user = state.users[userKey];
+      if (!user || !user.uploads || !user.uploads[uploadId]) {
+        throw new Error('upload_not_found');
+      }
+      const upload = user.uploads[uploadId];
+      const decorated = this._decorateUpload(upload);
+      if (!forget) {
+        user.history.unshift(this._toHistoryEntry(upload));
+        if (user.history.length > 200) {
+          user.history = user.history.slice(0, 200);
+        }
+      }
+      delete user.uploads[uploadId];
+      return decorated;
+    });
+  }
+
+  async assembleFile(upload) {
+    const safeName = this._safeFileName(upload.fileName);
+    const finalPath = path.join(this.finalDir, `${upload.id}-${safeName}`);
+    await fs.ensureDir(this.finalDir);
+    const writeStream = fs.createWriteStream(finalPath);
+
+    for (let i = 0; i < upload.totalChunks; i += 1) {
+      const chunkPath = path.join(this.uploadDir, upload.id, `${i}.part`);
+      const exists = await fs.pathExists(chunkPath);
+      if (!exists) {
+        writeStream.destroy();
+        throw new Error(`missing_chunk_${i}`);
+      }
+      await new Promise((resolve, reject) => {
+        const readStream = fs.createReadStream(chunkPath);
+        readStream.on('error', reject);
+        readStream.on('end', resolve);
+        readStream.pipe(writeStream, { end: false });
+      });
+    }
+
+    writeStream.end();
+    await new Promise((resolve, reject) => {
+      writeStream.on('finish', resolve);
+      writeStream.on('error', reject);
+    });
+
+    await fs.remove(path.join(this.uploadDir, upload.id));
+    return finalPath;
+  }
+
+  _safeFileName(name) {
+    return path.basename(name).replace(/[^A-Za-z0-9._-]/g, '_');
+  }
+}
+
+module.exports = UploadManager;


### PR DESCRIPTION
## Summary
- lazily load nanoid via dynamic import so it works in CommonJS mode
- cache the generated ID factories on the UploadManager instance and reuse them
- ensure user and upload creation paths wait for the generators before use

## Testing
- `node - <<'NODE'
const path = require('path');
const fs = require('fs-extra');
const UploadManager = require('./src/uploadManager');
(async () => {
  const tmpRoot = path.join(__dirname, '.tmp-test');
  await fs.remove(tmpRoot);
  const manager = new UploadManager({
    rootDir: tmpRoot,
    uploadDir: path.join(tmpRoot, 'uploads'),
    finalDir: path.join(tmpRoot, 'final'),
    statePath: path.join(tmpRoot, 'state.json'),
  });
  const { userKey, created } = await manager.identifyUser();
  console.log('user created?', created, 'length', userKey.length);
  const upload = await manager.createUpload(userKey, {
    fileName: 'test.bin',
    fileSize: 1024,
    chunkSize: 256,
    persist: true,
  });
  console.log('upload id length', upload.id.length);
})();
NODE`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68d1621865a4833291c2950c3048abf1